### PR TITLE
Missing: added two projects from 2022 with full marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Inoltre chiedo la cortesia di aggiungere una stella se pensi sia utile o per aum
 
 ### 2022 - 30/30L
 
+<https://github.com/laughinginloud/ing-sw-2022-manfredi-martelli-meneghin>
+
 <https://github.com/AndreaNeti/ing-sw-2022-Sanguineti-Santoro-Piras>
 
 <https://github.com/Frenk3D/ing-sw-2022-Previtera-Riccardi-Scaccia>
@@ -260,6 +262,8 @@ Inoltre chiedo la cortesia di aggiungere una stella se pensi sia utile o per aum
 <https://github.com/viols-code/ing-sw-2022-renne-resta-puccioni>
 
 <https://github.com/AleSassi/ingsw2022-AM26>
+
+<https://github.com/marcomole00/ing-sw-2022-longo-mole-negro>
 
 ### 2021 - 30/30L
 

--- a/README.md
+++ b/README.md
@@ -455,8 +455,6 @@ T.B.C
 
 <https://github.com/irinel-sarbu/ing-sw-2022-Rigamonti-Rogora-Sarbu>
 
-<https://github.com/laughinginloud/ing-sw-2022-manfredi-martelli-meneghin>
-
 <https://github.com/leonardodeclara/ingsw2022-AM52>
 
 <https://github.com/leonardopesce/ing-sw-2022-Pesce-Pertino-Paddeu>


### PR DESCRIPTION
The projects were added to the 2022 list, briefly comparing the quality of the README.md presents in the various repositories. The https://github.com/laughinginloud/ing-sw-2022-manfredi-martelli-meneghin project was favoured as it contains a wiki section and screenshots of the game, on top of being well organised. 

If the order was already decided based on other criteria, please review this PR, modifying the order of projects as you prefer.